### PR TITLE
make filesystem keep data for networks isolated to avoid collisions

### DIFF
--- a/shell/add-peer-to-network
+++ b/shell/add-peer-to-network
@@ -6,8 +6,8 @@ function add_peer_to_network() {
   local client_cidr="$2"
   local client_public_key_name="$3"
 
-  stat "/etc/wireguard/${client_public_key_name}"
-  local client_public_key=$(cat "/etc/wireguard/${client_public_key_name}")
+  stat $client_public_key_name
+  local client_public_key=$(cat "$client_public_key_name")
 
   local addition="$(cat << EOF
 
@@ -16,7 +16,7 @@ PublicKey = $client_public_key
 AllowedIPs = $client_cidr
 EOF
 )"
-  echo "$addition" >> "/etc/wireguard/${config_name}.conf"
+  echo "$addition" >> "$config_name"
 }
 
 function main() {
@@ -24,6 +24,7 @@ function main() {
   while true; do
     case "$1" in
       --config-name              ) CONFIG_NAME=$2; shift 2 ;;
+      --interface-name          ) INTERFACE_NAME=$2; shift 2;;
       --client-cidr             ) CLIENT_CIDR=$2; shift 2 ;;
       --client-public-key-name  ) PUBLIC_KEY_NAME=$2; shift 2 ;;
       -- ) shift; break ;;
@@ -33,8 +34,8 @@ function main() {
   set -u
 
   add_peer_to_network "$CONFIG_NAME" "$CLIENT_CIDR" "$PUBLIC_KEY_NAME"
-  wg syncconf "$CONFIG_NAME" <(wg-quick strip "$CONFIG_NAME")
-  wg-quick down "$CONFIG_NAME"
-  wg-quick up "$CONFIG_NAME"
+  wg syncconf "$INTERFACE_NAME" <(wg-quick strip "$CONFIG_NAME")
+  wg-quick down "$INTERFACE_NAME"
+  wg-quick up "$INTERFACE_NAME"
 }
 main "$@"

--- a/shell/create-client-config
+++ b/shell/create-client-config
@@ -11,11 +11,11 @@ function create_client_config() {
   local network_listen_port="$7"
   local allowed_ips="$8"
 
-  stat "/etc/wireguard/${client_private_key_name}"
-  local client_private_key=$(cat "/etc/wireguard/${client_private_key_name}")
+  stat "$client_private_key_name"
+  local client_private_key=$(cat "$client_private_key_name")
 
-  stat "/etc/wireguard/${network_public_key_name}"
-  local server_public_key=$(cat "/etc/wireguard/${network_public_key_name}")
+  stat "$network_public_key_name"
+  local server_public_key=$(cat "$network_public_key_name")
 
 
   local config="$(cat << EOF
@@ -29,7 +29,7 @@ Endpoint = $network_endpoint:$network_listen_port
 AllowedIPs = $allowed_ips
 EOF
 )"
-echo "$config" > "/etc/wireguard/${config_name}.conf"
+echo "$config" > "$config_name"
 }
 
 function main() {

--- a/shell/create-network-config
+++ b/shell/create-network-config
@@ -7,8 +7,8 @@ function create_config() {
   local network_listen_port="$3"
   local network_private_key_name="$4"
 
-  stat "/etc/wireguard/${network_private_key_name}"
-  local private_key=$(cat "/etc/wireguard/${network_private_key_name}")
+  stat "$network_private_key_name"
+  local private_key=$(cat "$network_private_key_name")
 
   config=$(cat << EOF
 [Interface]
@@ -17,7 +17,7 @@ ListenPort = $network_listen_port
 PrivateKey = $private_key
 EOF
 )
-  echo "$config" > "/etc/wireguard/${config_name}.conf"
+  echo "$config" > "$config_name"
 }
 
 function main() {

--- a/shell/remove-peer-from-network
+++ b/shell/remove-peer-from-network
@@ -16,15 +16,15 @@ function remove_peer_from_network() {
   local client_cidr="$2"
   local client_public_key_name="$3"
 
-  stat "/etc/wireguard/${client_public_key_name}"
-  local client_public_key=$(cat "/etc/wireguard/${client_public_key_name}")
+  stat "$client_public_key_name"
+  local client_public_key=$(cat "$client_public_key_name")
 
   local escaped_ip=$(escape_ip_for_sed $client_cidr)
   local escaped_key=$(escape_key_for_sed $client_public_key)
 
-  sed -i "/AllowedIPs = $escaped_ip/d" "/etc/wireguard/${config_name}.conf"
-  sed -i "/PublicKey = $escaped_key/d" "/etc/wireguard/${config_name}.conf"
-  sed -i "/\[Peer\] \# $escaped_ip/d" "/etc/wireguard/${config_name}.conf"
+  sed -i "/AllowedIPs = $escaped_ip/d" "$config_name"
+  sed -i "/PublicKey = $escaped_key/d" "$config_name"
+  sed -i "/\[Peer\] \# $escaped_ip/d" "$config_name"
 }
 
 function main() {
@@ -32,6 +32,7 @@ function main() {
   while true; do
     case "$1" in
       --config-name              ) CONFIG_NAME=$2; shift 2 ;;
+      --interface-name          ) INTERFACE_NAME=$2; shift 2;;
       --client-cidr             ) CLIENT_CIDR=$2; shift 2 ;;
       --client-public-key-name  ) PUBLIC_KEY_NAME=$2; shift 2 ;;
       -- ) shift; break ;;
@@ -41,8 +42,8 @@ function main() {
   set -u
 
   remove_peer_from_network "$CONFIG_NAME" "$CLIENT_CIDR" "$PUBLIC_KEY_NAME"
-  wg syncconf "$CONFIG_NAME" <(wg-quick strip "$CONFIG_NAME")
-  wg-quick down "$CONFIG_NAME"
-  wg-quick up "$CONFIG_NAME"
+  wg syncconf "$INTERFACE_NAME" <(wg-quick strip "$CONFIG_NAME")
+  wg-quick down "$INTERFACE_NAME"
+  wg-quick up "$INTERFACE_NAME"
 }
 main "$@"

--- a/src/main/java/com/brcsrc/yaws/model/Constants.java
+++ b/src/main/java/com/brcsrc/yaws/model/Constants.java
@@ -3,6 +3,8 @@ package com.brcsrc.yaws.model;
 public class Constants {
     // base controller url route
     public static final String BASE_URL = "/api/v1";
+    // base wireguard dir
+    public static final String BASE_WIREGUARD_DIR = "/etc/wireguard";
     // input validation regular expressions
     // network and client names
     public static final String CHAR_64_ALPHANUMERIC_REGEXP = "^[a-zA-Z0-9]+$";

--- a/src/main/java/com/brcsrc/yaws/shell/ExecutionResult.java
+++ b/src/main/java/com/brcsrc/yaws/shell/ExecutionResult.java
@@ -2,9 +2,11 @@ package com.brcsrc.yaws.shell;
 
 public class ExecutionResult {
     String stdout;
+    String stderr;
     int exitCode;
-    public ExecutionResult(String stdout, int exitCode) {
+    public ExecutionResult(String stdout, String stderr, int exitCode) {
         this.stdout = stdout;
+        this.stderr = stderr;
         this.exitCode = exitCode;
     }
 
@@ -14,6 +16,14 @@ public class ExecutionResult {
 
     public void setStdout(String stdout) {
         this.stdout = stdout;
+    }
+
+    public String getStderr() {
+        return stderr;
+    }
+
+    public void setStderr(String stderr) {
+        this.stderr = stderr;
     }
 
     public int getExitCode() {
@@ -28,6 +38,7 @@ public class ExecutionResult {
     public String toString() {
         return "ExecutionResult{" +
                 "stdout='" + stdout + '\'' +
+                ", stderr='" + stderr + '\'' +
                 ", exitCode=" + exitCode +
                 '}';
     }

--- a/src/main/java/com/brcsrc/yaws/shell/Executor.java
+++ b/src/main/java/com/brcsrc/yaws/shell/Executor.java
@@ -1,28 +1,36 @@
 package com.brcsrc.yaws.shell;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 
 
 public class Executor {
+
+    private static String readStdFromStream(InputStream inputStream) throws IOException {
+        StringBuilder std = new StringBuilder();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            std.append(line).append("\n");
+        }
+        return std.toString();
+    }
+
     public static ExecutionResult runCommand(String command) {
-        StringBuilder stdout = new StringBuilder();
+        String stdout = "";
+        String stderr = "";
         int exitCode = 1;
         try {
             ProcessBuilder processBuilder = new ProcessBuilder(command.split("\\s+"));
             Process process = processBuilder.start();
-            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-            String line;
-            while ((line = reader.readLine()) != null) {
-                stdout.append(line).append("\n");
-            }
+            stdout = readStdFromStream(process.getInputStream());
+            stderr = readStdFromStream(process.getErrorStream());
             exitCode = process.waitFor();
-
         } catch (IOException | InterruptedException e) {
             e.printStackTrace();
-            stdout.append(e.toString());
         }
-        return new ExecutionResult(stdout.toString(), exitCode);
+        return new ExecutionResult(stdout, stderr, exitCode);
     }
 }
 

--- a/src/main/java/com/brcsrc/yaws/utility/FilepathUtils.java
+++ b/src/main/java/com/brcsrc/yaws/utility/FilepathUtils.java
@@ -1,0 +1,80 @@
+package com.brcsrc.yaws.utility;
+
+
+import com.brcsrc.yaws.model.Constants;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+
+/**
+ * used to determine the absolute path of files on the system.
+ * if a change to where keys and configs need to be changed, we can
+ * control that here and not in the service layer
+ */
+public class FilepathUtils {
+    public static String getNetworkConfigPath(String networkName) {
+        return String.format(
+                "%s/%s.conf",
+                Constants.BASE_WIREGUARD_DIR,
+                networkName
+        );
+    }
+    public static String getNetworkDirectoryPath(String networkName) {
+        return String.format(
+                "%s/%s/",
+                Constants.BASE_WIREGUARD_DIR,
+                networkName
+        );
+    }
+    public static String getNetworkKeysDirectoryPath(String networkName) {
+        return String.format(
+                "%s/%s/keys/",
+                Constants.BASE_WIREGUARD_DIR,
+                networkName
+        );
+    }
+    public static String getNetworkClientsDirectoryPath(String networkName) {
+        return String.format(
+                "%s/%s/clients/",
+                Constants.BASE_WIREGUARD_DIR,
+                networkName
+        );
+    }
+    public static String getNetworkKeyPath(String networkName, String networkKeyName) {
+        return String.format(
+                "%s/%s/keys/%s",
+                Constants.BASE_WIREGUARD_DIR,
+                networkName,
+                networkKeyName
+        );
+    }
+    public static String getClientConfigPath(String networkName, String clientName) {
+        return String.format(
+                "%s/%s/clients/%s.conf",
+                Constants.BASE_WIREGUARD_DIR,
+                networkName,
+                clientName
+        );
+    }
+    public static String getClientKeyPath(String networkName, String clientKeyName) {
+        return String.format(
+                "%s/%s/keys/%s",
+                Constants.BASE_WIREGUARD_DIR,
+                networkName,
+                clientKeyName
+        );
+    }
+    public static void deleteDirectory(Path dir) throws IOException {
+        if (Files.exists(dir)) {
+            try (Stream<Path> walk = Files.walk(dir)) {
+                for (Path path : walk.sorted(Comparator.reverseOrder()).toList()) {
+                    Files.delete(path);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/brcsrc/yaws/api/NetworkClientControllerTests.java
+++ b/src/test/java/com/brcsrc/yaws/api/NetworkClientControllerTests.java
@@ -8,6 +8,7 @@ import com.brcsrc.yaws.persistence.NetworkClientRepository;
 import com.brcsrc.yaws.persistence.NetworkRepository;
 import com.brcsrc.yaws.service.NetworkClientService;
 import com.brcsrc.yaws.service.NetworkService;
+import com.brcsrc.yaws.utility.FilepathUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -142,11 +143,11 @@ public class NetworkClientControllerTests {
         assertEquals(savedNetworkClient.getClient().getClientPublicKeyName(), expectedClientPublicKeyFileName);
 
         // assert the client keys and config exist
-        // TODO this will likely break when migrating to network specific directories for file storage
-        String clientPublicKeyAbsPath = String.format("/etc/wireguard/%s", expectedClientPublicKeyFileName);
-        String clientPrivateKeyAbsPath = String.format("/etc/wireguard/%s", expectedClientPrivateKeyFileName);
-        String clientConfigAbsPath = String.format("/etc/wireguard/%s.conf", testClientName);
+        String clientPublicKeyAbsPath = FilepathUtils.getClientKeyPath(testNetworkName, expectedClientPublicKeyFileName);
+        String clientPrivateKeyAbsPath = FilepathUtils.getClientKeyPath(testNetworkName, expectedClientPrivateKeyFileName);
+        String clientConfigAbsPath = FilepathUtils.getClientConfigPath(testNetworkName, testClientName);
         var filePaths = List.of(
+                clientConfigAbsPath,
                 clientPrivateKeyAbsPath,
                 clientPublicKeyAbsPath
         );

--- a/src/test/java/com/brcsrc/yaws/shell/ExecutorTests.java
+++ b/src/test/java/com/brcsrc/yaws/shell/ExecutorTests.java
@@ -5,14 +5,24 @@ import org.junit.jupiter.api.Assertions;
 
 public class ExecutorTests {
     @Test
-    void testExecutorReturnsStdout(){
+    void testExecutorReturnsStdout() {
         ExecutionResult result = Executor.runCommand("which uname");
-        Assertions.assertTrue(result.stdout.startsWith("/bin/uname"));
+        Assertions.assertTrue(result.stdout.contains("/bin/uname"));
+        Assertions.assertEquals(0, result.exitCode);
+        Assertions.assertEquals("", result.stderr);
     }
 
     @Test
-    void testExecutorReturnsExitCode(){
+    void testExecutorReturnsExitCode() {
         ExecutionResult result = Executor.runCommand("which uname");
         Assertions.assertEquals(0, result.exitCode);
+    }
+
+    @Test
+    void testExecutorReturnsStderr() {
+        ExecutionResult result = Executor.runCommand("/bin/bash -c notacommand");
+        Assertions.assertEquals("", result.stdout);
+        Assertions.assertNotEquals(0, result.exitCode);
+        Assertions.assertTrue(result.stderr.contains("command not found"));
     }
 }


### PR DESCRIPTION
### Summary
The way keys and configurations were being stored would have led to data being overwritten in the hypothetical case of
1. client calls CreateNetwork with NetworkName `Network1`
2. client calls CreateNetworkClient with ClientName `Client1`
3. client calls CreateNetwork a second time with NetworkName `Network2`
4. client calls CreateNetworkClient a second time with ClientName `Client1` and the side effect of this is the private and public keys for Network1/Client1 have just been overwritten by Network2/Client1

so to avoid this issue we are now storing keys and configurations like this:
```
bash-5.1# tree /etc/wireguard/
/etc/wireguard/                                 # base directory
├── Network1                               # network specific directory by network name
│   ├── clients                                # clients for Network1 only
│   │   ├── Client1.conf
│   │   └── Client2.conf
│   └── keys                                  # keys for Network1 only
│       ├── Client1-private-key
│       ├── Client1-public-key
│       ├── Client2-private-key
│       ├── Client2-public-key
│       ├── Network1-private-key
│       └── Network1-public-key
└── Network1.conf                     # network configs are kept here so that `wg-quick` can be used but may change in the future
```

### Testing
all tests passing. added new tests for `Executor.runCommand` that should now return STDERR when commands fail