### PR TITLE
add startup task to restart existing wireguard networks on container restart

### DIFF
--- a/src/main/java/com/brcsrc/yaws/persistence/NetworkRepository.java
+++ b/src/main/java/com/brcsrc/yaws/persistence/NetworkRepository.java
@@ -1,8 +1,9 @@
 package com.brcsrc.yaws.persistence;
 
-
+import java.util.List;
 import java.util.Optional;
 
+import com.brcsrc.yaws.model.NetworkStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -22,4 +23,5 @@ public interface NetworkRepository extends JpaRepository<Network, String> {
                                                          @Param("networkCidr") String networkCidr,
                                                          @Param("networkListenPort") int networkListenPort);
 
+    List<Network> findAllByNetworkStatus(NetworkStatus networkStatus);
 }

--- a/src/main/java/com/brcsrc/yaws/startup/StartupListener.java
+++ b/src/main/java/com/brcsrc/yaws/startup/StartupListener.java
@@ -1,13 +1,25 @@
 package com.brcsrc.yaws.startup;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 @Component
 public class StartupListener {
+    private StartupTasks startupTasks;
+    private static final Logger logger = LoggerFactory.getLogger(StartupListener.class);
+
+    @Autowired
+    public StartupListener(StartupTasks startupTasks) {
+        this.startupTasks = startupTasks;
+    }
+
     @EventListener(ApplicationReadyEvent.class)
     public void onStartup() {
-        System.out.println("Application is ready, startup task executed");
+        logger.info("Application is ready, executing start up tasks");
+        this.startupTasks.restartActiveNetworks();
     }
 }

--- a/src/main/java/com/brcsrc/yaws/startup/StartupTasks.java
+++ b/src/main/java/com/brcsrc/yaws/startup/StartupTasks.java
@@ -1,0 +1,51 @@
+package com.brcsrc.yaws.startup;
+
+import com.brcsrc.yaws.exceptions.InternalServerException;
+import com.brcsrc.yaws.model.Network;
+import com.brcsrc.yaws.model.NetworkStatus;
+import com.brcsrc.yaws.persistence.NetworkRepository;
+import com.brcsrc.yaws.shell.ExecutionResult;
+import com.brcsrc.yaws.shell.Executor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class StartupTasks {
+    private final NetworkRepository networkRepository;
+    private static final Logger logger = LoggerFactory.getLogger(StartupTasks.class);
+
+    @Autowired
+    public StartupTasks(NetworkRepository networkRepository) {
+        this.networkRepository = networkRepository;
+    }
+
+    @Async
+    public void restartActiveNetworks() {
+        logger.info("restartActiveNetworks called, finding existing active networks to restart");
+        List<Network> activeNetworks = this.networkRepository.findAllByNetworkStatus(NetworkStatus.ACTIVE);
+        logger.info(String.format("found %s active networks to restart", activeNetworks.size()));
+        boolean errorsOnActivate = false;
+
+        for (Network network : activeNetworks) {
+            logger.info(String.format("activating existing network '%s'", network.getNetworkName()));
+            final String activateNetworkInterfaceCommand = String.format("wg-quick up %s", network.getNetworkName());
+            ExecutionResult activateResult = Executor.runCommand(activateNetworkInterfaceCommand);
+            if (activateResult.getExitCode() != 0) {
+                errorsOnActivate = true;
+                logger.error(String.format(
+                        "command: '%s' exited %s with reason: %s",
+                        activateNetworkInterfaceCommand,
+                        activateResult.getExitCode(),
+                        activateResult.getStderr()));
+            }
+        }
+        if (errorsOnActivate) {
+            throw new InternalServerException("restarkActiveNetworks ran into an error");
+        }
+    }
+}


### PR DESCRIPTION
### Summary
This PR will add a task to the StartupEventListener so that existing networks in ACTIVE state are restarted if the host or container are restarted


### Testing
created 3 networks and stopped and restarted the container
```
2025-03-02 17:26:29 2025-03-03T00:26:29.213Z  INFO 62 --- [yaws] [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port 8080 (http) with context path ''
2025-03-02 17:26:29 2025-03-03T00:26:29.242Z  INFO 62 --- [yaws] [           main] com.brcsrc.yaws.YawsApplication          : Started YawsApplication in 9.207 seconds (process running for 10.207)
2025-03-02 17:26:29 2025-03-03T00:26:29.245Z  INFO 62 --- [yaws] [           main] c.brcsrc.yaws.startup.StartupListener    : Application is ready, executing start up tasks
2025-03-02 17:26:29 2025-03-03T00:26:29.248Z  INFO 62 --- [yaws] [         task-1] com.brcsrc.yaws.startup.StartupTasks     : restartActiveNetworks called, finding existing active networks to restart
2025-03-02 17:26:29 2025-03-03T00:26:29.410Z  INFO 62 --- [yaws] [         task-1] com.brcsrc.yaws.startup.StartupTasks     : found 3 active networks to restart
2025-03-02 17:26:29 2025-03-03T00:26:29.411Z  INFO 62 --- [yaws] [         task-1] com.brcsrc.yaws.startup.StartupTasks     : activating existing network 'Network1'
2025-03-02 17:26:29 2025-03-03T00:26:29.434Z  INFO 62 --- [yaws] [         task-1] com.brcsrc.yaws.startup.StartupTasks     : activating existing network 'Network2'
2025-03-02 17:26:29 2025-03-03T00:26:29.454Z  INFO 62 --- [yaws] [         task-1] com.brcsrc.yaws.startup.StartupTasks     : activating existing network 'Network3'
```
and saw that wireguard was tracking the networks as active
```
/opt # wg
interface: Network1
  public key: 4fAzyQhEYTWEFTgq/COKFllm45/Gm2BBm/xKK3CXzHI=
  private key: (hidden)
  listening port: 51821

interface: Network2
  public key: VaAUrxQeRgIEq7hF0AVGeUbL827Zn1ixiXxP4tIGqW4=
  private key: (hidden)
  listening port: 51822

interface: Network3
  public key: O4zb1kyCsrMmfncNrWqexqq/i1sVD0VcbjGG1Q1GbWI=
  private key: (hidden)
  listening port: 51823
```
listen ports engaged
```
/opt # ss -tulpn
Netid                 State                   Recv-Q                  Send-Q                                   Local Address:Port                                    Peer Address:Port                 Process                 
udp                   UNCONN                  0                       0                                              0.0.0.0:51821                                        0.0.0.0:*                                            
udp                   UNCONN                  0                       0                                              0.0.0.0:51822                                        0.0.0.0:*                                            
udp                   UNCONN                  0                       0                                              0.0.0.0:51823                                        0.0.0.0:*       
```

### Issues
https://github.com/brcsrc/YetAnotherWireguardServer/issues/8