### PR TITLE
add more test coverage to CreateNetworkClient

### DIFF
--- a/src/main/java/com/brcsrc/yaws/service/NetworkClientService.java
+++ b/src/main/java/com/brcsrc/yaws/service/NetworkClientService.java
@@ -115,6 +115,17 @@ public class NetworkClientService {
             logger.error(errMsg);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errMsg);
         }
+        // check that the endpoint port is same as network listen port
+        int requestedPort = Integer.parseInt(request.getNetworkEndpoint().split(":")[1]);
+        if (requestedPort != existingNetwork.getNetworkListenPort()) {
+            String errMsg = String.format(
+                    "requested endpoint port '%s' does not match network listen port '%s'",
+                    requestedPort,
+                    existingNetwork.getNetworkListenPort()
+            );
+            logger.error(errMsg);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errMsg);
+        }
 
         // client relevant fields
         Client client = new Client();

--- a/src/main/java/com/brcsrc/yaws/utility/IPUtils.java
+++ b/src/main/java/com/brcsrc/yaws/utility/IPUtils.java
@@ -24,9 +24,9 @@ public class IPUtils {
             return false;
         }
 
-        String endpontPort = parts[1];
+        String endpointPort = parts[1];
         try {
-            int port = Integer.parseInt(endpontPort);
+            int port = Integer.parseInt(endpointPort);
             if (port <= 0 || port > 65535) {
                 return false;
             }

--- a/src/test/java/com/brcsrc/yaws/api/NetworkControllerTests.java
+++ b/src/test/java/com/brcsrc/yaws/api/NetworkControllerTests.java
@@ -21,9 +21,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.*;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.server.ResponseStatusException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
this PR adds more test coverage to CreateNetworkClient, mainly around making sure that input validation on that API correctly rejects bad requests