### PR TITLE
add basic authentication tests

### DIFF
--- a/src/main/java/com/brcsrc/yaws/model/responses/AuthenticationResponse.java
+++ b/src/main/java/com/brcsrc/yaws/model/responses/AuthenticationResponse.java
@@ -7,6 +7,8 @@ public class AuthenticationResponse {
     @Schema(description = "base64url-encoded string representation of the token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
     private String token;
 
+    public AuthenticationResponse() {}
+
     public AuthenticationResponse(String token) {
         this.token = token;
     }

--- a/src/test/java/com/brcsrc/yaws/api/NetworkControllerTests.java
+++ b/src/test/java/com/brcsrc/yaws/api/NetworkControllerTests.java
@@ -97,6 +97,30 @@ public class NetworkControllerTests {
     }
 
     @Test
+    public void testNetworkControllerRequiresAuthenticationToken() {
+        Network network = new Network();
+        network.setNetworkName(testNetworkName);
+        network.setNetworkCidr(testNetworkCidr);
+        network.setNetworkListenPort(testNetworkListenPort);
+        network.setNetworkTag(testNetworkTag);
+
+        String createNetworkUrl = baseUrl;
+
+        ResponseEntity<String> createNetworkResponse = restClient.post()
+                .uri(createNetworkUrl)
+                .body(network)
+                .exchange((request, response) -> {
+                    String body = response.bodyTo(String.class);
+                    return ResponseEntity.status(response.getStatusCode()).body(body);
+                });
+
+        assertEquals(HttpStatus.FORBIDDEN, createNetworkResponse.getStatusCode());
+        String createNetworkResponseBody = createNetworkResponse.getBody();
+        assert createNetworkResponseBody != null;
+        assertTrue(createNetworkResponseBody.contains("Access Denied"));
+    }
+
+    @Test
     public void testCreateNetworkCreatesNetwork() {
         Network network = new Network();
         network.setNetworkName(testNetworkName);


### PR DESCRIPTION
### Summary
 this PR adds tests around the `/authenticate` apis to make sure that we are responding in a way that attackers cant determine when only one of a username or password is correct, but not both. It also tests that the `/networks` apis require authentication

### Testing
all tests passing
```shell
 ./scripts/test-runner.sh run-tests 
```