### PR TITLE
make prod build that does not depend on development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,29 @@
 
 YetAnotherWireguardServer is a containerized Wireguard server designed to run anywhere you can run Docker.
 
+##### Try it yourself
+1. Clone the Repository
+```shell
+git clone https://github.com/brcsrc/YetAnotherWireguardServer
+```
+2. Build the Image
+> Requires Docker
+```shell
+cd YetAnotherWireguardServer && docker build -f docker/prod/Dockerfile -t yaws .
+```
+3. Run the Application with necessary network settings
+```shell
+docker run \
+ --privileged \
+ --cap-add=NET_ADMIN \
+ -p 0.0.0.0:51820:51820/udp \
+ -p 0.0.0.0:8080:8080/tcp \
+ --name yaws \
+ -d \
+ yaws:latest
+```
+
+
 ##### *Links*
 
 - [Development](doc/DEVELOPMENT.md)

--- a/doc/DEVELOPMENT.md
+++ b/doc/DEVELOPMENT.md
@@ -31,7 +31,7 @@ the jars from gradle dependencies are cached in `lib/` to remove the need to dow
 this will start the container locally for behavior testing
 ```shell
 \
-docker build -f docker/prod/Dockerfile -t yaws . && \
+docker build -f docker/dev/Dockerfile -t yaws . && \
 docker run \
  --privileged \
  --cap-add=NET_ADMIN \

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -13,10 +13,17 @@ RUN npm install && npm run build
 FROM gradle:8.9.0-jdk21-alpine AS build-spring
 WORKDIR /opt
 COPY build.gradle settings.gradle ./
+# this stage assumes we have already ran the gradle steps in the README
+# i.e. ./gradlew downloadGradleBin && ./gradlew copyDependenciesToLocalRepo
+# this is to reduce build time as much as we can
+COPY gradle gradle
+COPY gradlew gradlew
 COPY shell/* .
 COPY src/ src/
+COPY lib/ lib/
 COPY --from=build-frontend /app/yaws-frontend/dist /opt/src/main/resources/static
-RUN gradle wrapper
+# skipping tests here as we want to build only and not modify container. also system
+# level dependencies like wireguard are not in the environment at this point and tests wont pass here
 RUN ./gradlew build -x test --no-daemon;
 
 #### stage 3 build environment ###

--- a/docker/dev/entrypoint.sh
+++ b/docker/dev/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+# start openrc
+openrc
+touch /run/openrc/softlevel
+
+# enable forwarding and restore existing iptables if exist
+touch /etc/iptables/rules.v4
+echo '
+# /etc/conf.d/iptables
+IPTABLES_SAVE="/etc/iptables/rules-save"
+SAVE_RESTORE_OPTIONS="-c"
+SAVE_ON_STOP="yes"
+IPFORWARD="yes"
+' > /etc/conf.d/iptables
+/etc/init.d/iptables save
+iptables-restore < /etc/iptables/rules.v4
+
+# enable ip forward in sysctl
+echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
+sysctl -w net.ipv4.ip_forward=1
+
+# run spring application
+java -jar yaws-0.0.1-SNAPSHOT.jar


### PR DESCRIPTION
this is to support building and running the application on `amd64` and `arm64` platforms. Jon tested successfully on a Graviton instance and verified app health. The existing build process works which prioritizes build speed