### PR TITLE
fix login token issue, disable client creation on INACTIVE networks

### DIFF
--- a/src/main/java/com/brcsrc/yaws/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/brcsrc/yaws/security/JwtAuthenticationFilter.java
@@ -57,7 +57,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         } catch (SignatureException e) {
             String errMsg = String.format("jwt is invalid: %s", e.getMessage());
             logger.error(errMsg);
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, errMsg);
+            // Set 401 status and clear the invalid token cookie
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setHeader("Set-Cookie", "accessToken=; Max-Age=0; Path=/; HttpOnly; SameSite=Strict");
+            return;
         }
 
         logger.info(String.format("username from jwt: %s", userName));

--- a/src/main/java/com/brcsrc/yaws/utility/IPUtils.java
+++ b/src/main/java/com/brcsrc/yaws/utility/IPUtils.java
@@ -63,7 +63,7 @@ public class IPUtils {
 
         // they technically should be able to use a smaller subnet mask on the client
         // but the client would lose routing to other hosts on the same network
-        if (networkSubnetMask < networkMemberSubnetMask) {
+        if (networkMemberSubnetMask != 32 && networkSubnetMask < networkMemberSubnetMask) {
             throw new IllegalArgumentException(String.format("client subnet mask /%s is outside of network subnet mask /%s", networkMemberSubnetMask, networkSubnetMask));
         }
 

--- a/yaws-frontend/src/pages/client/Clients.tsx
+++ b/yaws-frontend/src/pages/client/Clients.tsx
@@ -1,14 +1,15 @@
 import { SpaceBetween } from "@cloudscape-design/components";
 import ClientsTable from "./components/ClientsTable";
+import {Network} from "yaws-ts-api-client/dist/types/models/Network";
 
 interface ClientsProps {
-  networkName: string;
+  network: Network
 }
 
-const Clients = ({ networkName }: ClientsProps) => {
+const Clients = ({ network }: ClientsProps) => {
   return (
     <SpaceBetween size="l">
-      <ClientsTable networkName={networkName} showCreateButton={true}/>
+      <ClientsTable network={network} showCreateButton={true}/>
     </SpaceBetween>
   );
 }

--- a/yaws-frontend/src/pages/client/CreateClient.tsx
+++ b/yaws-frontend/src/pages/client/CreateClient.tsx
@@ -19,9 +19,10 @@ const CreateClient = () => {
   const { addFlashbarItem } = useFlashbarContext();
 
   const [clientName, setClientName] = useState("");
-  const [clientCidr, setClientCidr] = useState("");
+  const [clientIp, setClientIp] = useState("");
+  const [clientSubnetMask, setClientSubnetMask] = useState("/32");
   const [clientDns, setClientDns] = useState("");
-  const [allowedIps, setAllowedIps] = useState("");
+  const [allowedIps, setAllowedIps] = useState("0.0.0.0/0");
   const [networkEndpoint, setNetworkEndpoint] = useState("");
 
   const [activeStepIndex, setActiveStepIndex] = useState(0);
@@ -31,6 +32,7 @@ const CreateClient = () => {
   const handleSubmit = async () => {
     setLoading(true);
     try {
+      const clientCidr = `${clientIp}${clientSubnetMask}`;
       await networkClientClient.createNetworkClient({
         createNetworkClientRequest: {
           clientName,
@@ -65,7 +67,8 @@ const CreateClient = () => {
 
   const isConfigureStepValid = () => {
     return clientName.trim() !== "" &&
-           clientCidr.trim() !== "" &&
+           clientIp.trim() !== "" &&
+           clientSubnetMask.trim() !== "" &&
            clientDns.trim() !== "" &&
            allowedIps.trim() !== "" &&
            networkEndpoint.trim() !== "";
@@ -131,14 +134,25 @@ const CreateClient = () => {
                 </FormField>
 
                 <FormField
-                  label="Client CIDR"
-                  description="CIDR block for the client"
+                  label="Client IP address / Subnet mask"
+                  description="IP address and subnet mask for the client (typically /32 for single device)"
                 >
-                  <Input
-                    value={clientCidr}
-                    onChange={({ detail }) => setClientCidr(detail.value)}
-                    placeholder="e.g., 10.100.0.3/24"
-                  />
+                  <div style={{ display: "flex", gap: "8px" }}>
+                    <div style={{ flex: "3" }}>
+                      <Input
+                        value={clientIp}
+                        onChange={({ detail }) => setClientIp(detail.value)}
+                        placeholder="e.g., 10.100.0.3"
+                      />
+                    </div>
+                    <div style={{ flex: "1" }}>
+                      <Input
+                        value={clientSubnetMask}
+                        onChange={({ detail }) => setClientSubnetMask(detail.value)}
+                        placeholder="/32"
+                      />
+                    </div>
+                  </div>
                 </FormField>
 
                 <FormField
@@ -195,8 +209,12 @@ const CreateClient = () => {
                         value: clientName || "-"
                       },
                       {
-                        label: "Client CIDR",
-                        value: clientCidr || "-"
+                        label: "Client IP address",
+                        value: clientIp || "-"
+                      },
+                      {
+                        label: "Subnet mask",
+                        value: clientSubnetMask || "-"
                       }
                     ]}
                   />

--- a/yaws-frontend/src/pages/network/CreateNetwork.tsx
+++ b/yaws-frontend/src/pages/network/CreateNetwork.tsx
@@ -18,7 +18,8 @@ const CreateNetwork = () => {
   const { addFlashbarItem } = useFlashbarContext();
 
   const [networkName, setNetworkName] = useState("");
-  const [networkCidr, setNetworkCidr] = useState("");
+  const [networkIp, setNetworkIp] = useState("");
+  const [networkSubnetMask, setNetworkSubnetMask] = useState("/24");
   const [networkListenPort, setNetworkListenPort] = useState("");
   const [networkTag, setNetworkTag] = useState("");
 
@@ -29,6 +30,7 @@ const CreateNetwork = () => {
   const handleSubmit = async () => {
     setLoading(true);
     try {
+      const networkCidr = `${networkIp}${networkSubnetMask}`;
       await networkClient.createNetwork({
         network: {
           networkName,
@@ -61,7 +63,8 @@ const CreateNetwork = () => {
 
   const isConfigureStepValid = () => {
     return networkName.trim() !== "" &&
-           networkCidr.trim() !== "" &&
+           networkIp.trim() !== "" &&
+           networkSubnetMask.trim() !== "" &&
            networkListenPort.trim() !== "" &&
            !isNaN(parseInt(networkListenPort));
   };
@@ -116,14 +119,25 @@ const CreateNetwork = () => {
                 </FormField>
 
                 <FormField
-                  label="Network CIDR"
-                  description="CIDR block for the network"
+                  label="Network IP address / Subnet mask"
+                  description="IP address and subnet mask for the network (typically /24)"
                 >
-                  <Input
-                    value={networkCidr}
-                    onChange={({ detail }) => setNetworkCidr(detail.value)}
-                    placeholder="e.g., 10.100.0.1/24"
-                  />
+                  <div style={{ display: "flex", gap: "8px" }}>
+                    <div style={{ flex: "3" }}>
+                      <Input
+                        value={networkIp}
+                        onChange={({ detail }) => setNetworkIp(detail.value)}
+                        placeholder="e.g., 10.100.0.1"
+                      />
+                    </div>
+                    <div style={{ flex: "1" }}>
+                      <Input
+                        value={networkSubnetMask}
+                        onChange={({ detail }) => setNetworkSubnetMask(detail.value)}
+                        placeholder="/24"
+                      />
+                    </div>
+                  </div>
                 </FormField>
 
                 <FormField
@@ -166,8 +180,12 @@ const CreateNetwork = () => {
                         value: networkName || "-"
                       },
                       {
-                        label: "Network CIDR",
-                        value: networkCidr || "-"
+                        label: "Network IP address",
+                        value: networkIp || "-"
+                      },
+                      {
+                        label: "Subnet mask",
+                        value: networkSubnetMask || "-"
                       }
                     ]}
                   />

--- a/yaws-frontend/src/pages/network/Network.tsx
+++ b/yaws-frontend/src/pages/network/Network.tsx
@@ -178,7 +178,7 @@ const Network = () => {
           {
             id: "clients",
             label: "Clients",
-            content: <Clients networkName={networkName} />
+            content: <Clients network={network} />
           }
         ]}
       />


### PR DESCRIPTION
There was an issue where if an expired token/token created from a different HMAC was sent in a request, the app could not recover without clearing the old token. now the app will send the token with no content and a header with an immediate expiry which will cause the browser to clear the token automatically.

There was also another issue where adding a client to a network that is INACTIVE would throw a server error as the process relies on the interface existing. since we bring the interface down when making a network INACTIVE this would cause a failure to add the client, now we have validation front and back for this