### PR TITLE
add ec2 deployment infra for testing, add CORS configuration for deployment behind proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ docker run \
  yaws:latest
 ```
 
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `DEV` | Enables development mode (allows Swagger UI, permits localhost CORS) | `-e DEV="true"` |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated list of allowed CORS origins, usually needed when deployed behind a proxy | `-e CORS_ALLOWED_ORIGINS="https://example.com,https://app.example.com"` |
 
 ##### *Links*
 

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -7,7 +7,7 @@ RUN npm install && npm run build
 WORKDIR /app
 COPY yaws-frontend/ /app/yaws-frontend/
 WORKDIR yaws-frontend
-RUN npm install && npm run build-dev
+RUN npm install && npm run build
 
 ### stage 2 build java artifact ###
 FROM gradle:8.9.0-jdk21-alpine AS build-spring

--- a/scripts/deploy-to-ec2.sh
+++ b/scripts/deploy-to-ec2.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+#
+# Deploy YAWS to AWS EC2 development environment
+#
+# Usage:
+#   ./scripts/deploy-to-ec2.sh deploy                - Full deployment (CloudFormation + Docker build/push + ASG refresh)
+#   ./scripts/deploy-to-ec2.sh deploy --skip-stack   - Skip CloudFormation, just build/push Docker image and refresh ASG
+#   ./scripts/deploy-to-ec2.sh teardown              - Delete stack and clean up all resources
+#
+# Options:
+#   --stack-name NAME    Override default stack name (default: yaws-dev)
+#   --image-tag TAG      Override default image tag (default: latest)
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+AWS_REGION="us-west-2"
+STACK_NAME="yaws-dev"
+TEMPLATE_FILE="${SCRIPT_DIR}/ec2-based-infrastructure.yml"
+DOCKERFILE="${PROJECT_ROOT}/docker/prod/Dockerfile"
+IMAGE_TAG="latest"
+
+function log_info() {
+  echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ") INFO [deploy-to-ec2] $1"
+}
+
+function log_error() {
+  echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ") ERROR [deploy-to-ec2] $1" >&2
+}
+
+function check_aws_cli() {
+  if ! command -v aws &> /dev/null; then
+    log_error "AWS CLI is not installed. Please install it first."
+    exit 1
+  fi
+
+  log_info "checking AWS credentials"
+  if ! aws sts get-caller-identity --region "${AWS_REGION}" &> /dev/null; then
+    log_error "AWS credentials not configured or invalid"
+    exit 1
+  fi
+}
+
+function check_docker() {
+  if ! command -v docker &> /dev/null; then
+    log_error "Docker is not installed. Please install it first."
+    exit 1
+  fi
+
+  if ! docker info &> /dev/null; then
+    log_error "Docker daemon is not running"
+    exit 1
+  fi
+}
+
+function get_ecr_repository_uri() {
+  local stack_name="$1"
+
+  aws cloudformation describe-stacks \
+    --stack-name "${stack_name}" \
+    --region "${AWS_REGION}" \
+    --query 'Stacks[0].Outputs[?OutputKey==`ECRRepositoryUri`].OutputValue' \
+    --output text 2>/dev/null || echo ""
+}
+
+function get_stack_status() {
+  local stack_name="$1"
+
+  aws cloudformation describe-stacks \
+    --stack-name "${stack_name}" \
+    --region "${AWS_REGION}" \
+    --query 'Stacks[0].StackStatus' \
+    --output text 2>/dev/null || echo "DOES_NOT_EXIST"
+}
+
+function deploy_cloudformation_stack() {
+  local stack_name="$1"
+  local template_file="$2"
+  local allowed_ip="$3"
+
+  local stack_status=$(get_stack_status "${stack_name}")
+
+  local parameters=""
+  if [[ -n "${allowed_ip}" ]]; then
+    parameters="--parameters ParameterKey=AllowedIP,ParameterValue=${allowed_ip}"
+  fi
+
+  if [[ "${stack_status}" == "DOES_NOT_EXIST" ]]; then
+    log_info "creating CloudFormation stack: ${stack_name}"
+    aws cloudformation create-stack \
+      --stack-name "${stack_name}" \
+      --template-body "file://${template_file}" \
+      --capabilities CAPABILITY_NAMED_IAM \
+      --region "${AWS_REGION}" \
+      ${parameters}
+
+    log_info "waiting for stack creation to complete (this may take several minutes)"
+    aws cloudformation wait stack-create-complete \
+      --stack-name "${stack_name}" \
+      --region "${AWS_REGION}"
+
+    log_info "stack created successfully"
+  else
+    log_info "updating CloudFormation stack: ${stack_name} (current status: ${stack_status})"
+
+    set +e
+    aws cloudformation update-stack \
+      --stack-name "${stack_name}" \
+      --template-body "file://${template_file}" \
+      --capabilities CAPABILITY_NAMED_IAM \
+      --region "${AWS_REGION}" \
+      ${parameters} 2>&1 | tee /tmp/update-stack-output.txt
+
+    local update_exit_code=$?
+    set -e
+
+    if [[ $update_exit_code -eq 0 ]]; then
+      log_info "waiting for stack update to complete"
+      aws cloudformation wait stack-update-complete \
+        --stack-name "${stack_name}" \
+        --region "${AWS_REGION}"
+      log_info "stack updated successfully"
+    elif grep -q "No updates are to be performed" /tmp/update-stack-output.txt; then
+      log_info "no stack updates required"
+    else
+      log_error "stack update failed"
+      exit 1
+    fi
+  fi
+}
+
+function build_and_push_image() {
+  local ecr_uri="$1"
+  local image_tag="$2"
+
+  log_info "building Docker image from ${DOCKERFILE}"
+  docker build \
+    -f "${DOCKERFILE}" \
+    -t "${ecr_uri}:${image_tag}" \
+    "${PROJECT_ROOT}"
+
+  log_info "logging in to ECR"
+  aws ecr get-login-password --region "${AWS_REGION}" | \
+    docker login --username AWS --password-stdin "${ecr_uri}"
+
+  log_info "pushing image to ECR: ${ecr_uri}:${image_tag}"
+  docker push "${ecr_uri}:${image_tag}"
+
+  log_info "image pushed successfully"
+}
+
+function refresh_asg() {
+  local stack_name="$1"
+
+  local asg_name=$(aws cloudformation describe-stacks \
+    --stack-name "${stack_name}" \
+    --region "${AWS_REGION}" \
+    --query 'Stacks[0].Outputs[?OutputKey==`AutoScalingGroupName`].OutputValue' \
+    --output text 2>/dev/null)
+
+  if [[ -z "${asg_name}" ]]; then
+    log_error "could not retrieve Auto Scaling Group name from stack outputs"
+    return 1
+  fi
+
+  log_info "starting instance refresh for ASG: ${asg_name}"
+
+  local refresh_id=$(aws autoscaling start-instance-refresh \
+    --auto-scaling-group-name "${asg_name}" \
+    --region "${AWS_REGION}" \
+    --query 'InstanceRefreshId' \
+    --output text)
+
+  log_info "instance refresh initiated (ID: ${refresh_id})"
+  log_info "waiting for instance refresh to complete (this may take several minutes)"
+
+  while true; do
+    local refresh_status=$(aws autoscaling describe-instance-refreshes \
+      --auto-scaling-group-name "${asg_name}" \
+      --instance-refresh-ids "${refresh_id}" \
+      --region "${AWS_REGION}" \
+      --query 'InstanceRefreshes[0].Status' \
+      --output text)
+
+    if [[ "${refresh_status}" == "Successful" ]]; then
+      log_info "instance refresh completed successfully"
+      break
+    elif [[ "${refresh_status}" == "Failed" || "${refresh_status}" == "Cancelled" ]]; then
+      log_error "instance refresh ${refresh_status}"
+      return 1
+    else
+      log_info "instance refresh status: ${refresh_status}"
+      sleep 10
+    fi
+  done
+}
+
+function get_instance_public_dns() {
+  local stack_name="$1"
+
+  local asg_name=$(aws cloudformation describe-stacks \
+    --stack-name "${stack_name}" \
+    --region "${AWS_REGION}" \
+    --query 'Stacks[0].Outputs[?OutputKey==`AutoScalingGroupName`].OutputValue' \
+    --output text)
+
+  local instance_id=$(aws autoscaling describe-auto-scaling-groups \
+    --auto-scaling-group-names "${asg_name}" \
+    --region "${AWS_REGION}" \
+    --query 'AutoScalingGroups[0].Instances[0].InstanceId' \
+    --output text)
+
+  if [[ -z "${instance_id}" || "${instance_id}" == "None" ]]; then
+    log_error "no running instance found in ASG"
+    return 1
+  fi
+
+  local public_dns=$(aws ec2 describe-instances \
+    --instance-ids "${instance_id}" \
+    --region "${AWS_REGION}" \
+    --query 'Reservations[0].Instances[0].PublicDnsName' \
+    --output text)
+
+  echo "${public_dns}"
+}
+
+function print_deployment_info() {
+  local stack_name="$1"
+
+  log_info "deployment complete!"
+  log_info "stack outputs:"
+
+  aws cloudformation describe-stacks \
+    --stack-name "${stack_name}" \
+    --region "${AWS_REGION}" \
+    --query 'Stacks[0].Outputs[*].[OutputKey,OutputValue]' \
+    --output table
+
+  local public_dns=$(get_instance_public_dns "${stack_name}")
+
+  if [[ -n "${public_dns}" && "${public_dns}" != "None" ]]; then
+    log_info "instance public DNS: ${public_dns}"
+    log_info "connect via SSM: aws ssm start-session --target \$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names ${stack_name}-asg --region ${AWS_REGION} --query 'AutoScalingGroups[0].Instances[0].InstanceId' --output text) --region ${AWS_REGION}"
+  else
+    log_info "instance is still launching, public DNS not yet available"
+  fi
+}
+
+function deploy() {
+  local skip_stack="$1"
+
+  check_aws_cli
+  check_docker
+
+  log_info "deploying YAWS to AWS EC2"
+  log_info "region: ${AWS_REGION}"
+  log_info "stack: ${STACK_NAME}"
+
+  if [[ "${skip_stack}" != "true" ]]; then
+    local allowed_ip="$(curl -s ifconfig.me)/32"
+    log_info "restricting access to: ${allowed_ip} (443/tcp), 51820/udp open to all"
+    deploy_cloudformation_stack "${STACK_NAME}" "${TEMPLATE_FILE}" "${allowed_ip}"
+  else
+    log_info "skipping CloudFormation stack deployment"
+  fi
+
+  local ecr_uri=$(get_ecr_repository_uri "${STACK_NAME}")
+
+  if [[ -z "${ecr_uri}" ]]; then
+    log_error "could not retrieve ECR repository URI from stack outputs"
+    exit 1
+  fi
+
+  build_and_push_image "${ecr_uri}" "${IMAGE_TAG}"
+  refresh_asg "${STACK_NAME}"
+
+  print_deployment_info "${STACK_NAME}"
+}
+
+function teardown() {
+  check_aws_cli
+
+  log_info "tearing down YAWS EC2 environment"
+  log_info "stack: ${STACK_NAME}"
+
+  local stack_status=$(get_stack_status "${STACK_NAME}")
+
+  if [[ "${stack_status}" == "DOES_NOT_EXIST" ]]; then
+    log_info "stack does not exist, nothing to tear down"
+    return 0
+  fi
+
+  # Empty ECR repository before deletion
+  local ecr_repo_name=$(aws cloudformation describe-stacks \
+    --stack-name "${STACK_NAME}" \
+    --region "${AWS_REGION}" \
+    --query 'Stacks[0].Outputs[?OutputKey==`ECRRepositoryName`].OutputValue' \
+    --output text 2>/dev/null)
+
+  if [[ -n "${ecr_repo_name}" ]]; then
+    log_info "deleting all images from ECR repository: ${ecr_repo_name}"
+
+    set +e
+    local image_ids=$(aws ecr list-images \
+      --repository-name "${ecr_repo_name}" \
+      --region "${AWS_REGION}" \
+      --query 'imageIds[*]' \
+      --output json 2>/dev/null)
+    set -e
+
+    if [[ -n "${image_ids}" && "${image_ids}" != "[]" ]]; then
+      aws ecr batch-delete-image \
+        --repository-name "${ecr_repo_name}" \
+        --region "${AWS_REGION}" \
+        --image-ids "${image_ids}" &>/dev/null || true
+    fi
+  fi
+
+  log_info "deleting CloudFormation stack: ${STACK_NAME}"
+  aws cloudformation delete-stack \
+    --stack-name "${STACK_NAME}" \
+    --region "${AWS_REGION}"
+
+  log_info "waiting for stack deletion to complete"
+  aws cloudformation wait stack-delete-complete \
+    --stack-name "${STACK_NAME}" \
+    --region "${AWS_REGION}"
+
+  log_info "stack deleted successfully"
+}
+
+function main() {
+  local OPERATION=""
+  local SKIP_STACK="false"
+
+  while true; do
+    case "$1" in
+      deploy                ) OPERATION="deploy"; shift 1;;
+      teardown              ) OPERATION="teardown"; shift 1;;
+      --skip-stack          ) SKIP_STACK="true"; shift 1;;
+      --stack-name          ) STACK_NAME="${2:-}"; shift 2;;
+      --image-tag           ) IMAGE_TAG="${2:-}"; shift 2;;
+      -- ) shift; break ;;
+      * ) break ;;
+    esac
+  done
+
+  case "$OPERATION" in
+    "deploy")
+      deploy "$SKIP_STACK"
+      ;;
+    "teardown")
+      teardown
+      ;;
+    *)
+      log_error "invalid operation. Usage: $0 {deploy|teardown} [--skip-stack] [--stack-name NAME] [--image-tag TAG]"
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/ec2-based-infrastructure.yml
+++ b/scripts/ec2-based-infrastructure.yml
@@ -1,0 +1,272 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'YAWS Development Environment - ECR, EC2, and supporting infrastructure for testing VPN server'
+
+Parameters:
+  EnvironmentName:
+    Type: String
+    Default: yaws-dev
+    Description: Environment name prefix for resources
+
+  InstanceType:
+    Type: String
+    Default: t3.small
+    Description: EC2 instance type
+    AllowedValues:
+      - t3.micro
+      - t3.small
+      - t3.medium
+
+  LatestAmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
+    Description: Latest Amazon Linux 2023 AMI ID from SSM Parameter Store
+
+  AllowedIP:
+    Type: String
+    Default: 0.0.0.0/0
+    Description: IP address CIDR to allow HTTPS access (default allows all)
+
+Resources:
+  # ECR Repository for Docker images
+  ECRRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Sub '${EnvironmentName}'
+      ImageScanningConfiguration:
+        ScanOnPush: false
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "Keep only 1 image",
+                "selection": {
+                  "tagStatus": "any",
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 1
+                },
+                "action": {
+                  "type": "expire"
+                }
+              }
+            ]
+          }
+
+  # IAM Role for EC2 Instance
+  EC2InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${EnvironmentName}-ec2-role'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
+      Policies:
+        - PolicyName: ECRPullPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'ecr:GetAuthorizationToken'
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - 'ecr:BatchCheckLayerAvailability'
+                  - 'ecr:GetDownloadUrlForLayer'
+                  - 'ecr:BatchGetImage'
+                Resource: !GetAtt ECRRepository.Arn
+
+  # Instance Profile for EC2
+  EC2InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: !Sub '${EnvironmentName}-instance-profile'
+      Roles:
+        - !Ref EC2InstanceRole
+
+  # Security Group for YAWS
+  YAWSSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for YAWS VPN server - allows HTTPS and WireGuard traffic
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: !Ref AllowedIP
+          Description: HTTPS traffic
+        - IpProtocol: udp
+          FromPort: 51820
+          ToPort: 51820
+          CidrIp: 0.0.0.0/0
+          Description: WireGuard VPN traffic
+      Tags:
+        - Key: Name
+          Value: !Sub '${EnvironmentName}-sg'
+
+  # Launch Template for ASG
+  LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: !Sub '${EnvironmentName}-launch-template'
+      LaunchTemplateData:
+        ImageId: !Ref LatestAmiId
+        InstanceType: !Ref InstanceType
+        IamInstanceProfile:
+          Arn: !GetAtt EC2InstanceProfile.Arn
+        SecurityGroupIds:
+          - !GetAtt YAWSSecurityGroup.GroupId
+        MetadataOptions:
+          HttpTokens: required
+          HttpPutResponseHopLimit: 1
+        TagSpecifications:
+          - ResourceType: instance
+            Tags:
+              - Key: Name
+                Value: !Sub '${EnvironmentName}-instance'
+              - Key: Environment
+                Value: !Ref EnvironmentName
+        UserData:
+          Fn::Base64: !Sub |
+            #!/bin/bash
+            set -euo pipefail
+
+            # Install Docker
+            yum update -y
+            yum install -y docker openssl
+            systemctl start docker
+            systemctl enable docker
+
+            # Setup jnb-relay
+            mkdir -p /opt/jnb-relay
+            cd /opt/jnb-relay
+
+            # Download jnb-relay binary
+            curl -L -o jnb-relay https://github.com/brcsrc/JnbRelay/releases/download/v1.0.0-linux-x86_64/jnb-relay
+            chmod +x jnb-relay
+
+            # Generate self-signed certificate
+            openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.crt -sha256 -days 3650 -nodes -subj "/C=US/ST=State/L=City/O=YAWS/OU=Dev/CN=localhost"
+
+            # Create systemd service for jnb-relay
+            cat > /etc/systemd/system/jnb-relay.service <<EOF
+            [Unit]
+            Description=JnbRelay TLS Proxy
+            After=network.target
+
+            [Service]
+            Type=simple
+            WorkingDirectory=/opt/jnb-relay
+            ExecStart=/opt/jnb-relay/jnb-relay --host 0.0.0.0 --port 443 --proxy-for-host 127.0.0.1 --proxy-for-port 8080 --cert cert.crt --key key.pem
+            Restart=always
+            RestartSec=5
+
+            [Install]
+            WantedBy=multi-user.target
+            EOF
+
+            systemctl daemon-reload
+            systemctl enable jnb-relay
+            systemctl start jnb-relay
+
+            # Get instance public DNS for CORS configuration
+            TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+            PUBLIC_DNS=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/public-hostname)
+
+            # Login to ECR and pull YAWS image
+            aws ecr get-login-password --region ${AWS::Region} | docker login --username AWS --password-stdin ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com
+            docker pull ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${EnvironmentName}:latest
+
+            # Run YAWS container
+            docker run \
+              --privileged \
+              --cap-add=NET_ADMIN \
+              -e CORS_ALLOWED_ORIGINS="https://$PUBLIC_DNS" \
+              -p 0.0.0.0:51820:51820/udp \
+              -p 127.0.0.1:8080:8080/tcp \
+              --name yaws \
+              --restart unless-stopped \
+              -d \
+              ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${EnvironmentName}:latest
+
+            echo "UserData executed successfully at $(date)" > /var/log/yaws-userdata.log
+
+  # Auto Scaling Group with 1 instance
+  AutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      AutoScalingGroupName: !Sub '${EnvironmentName}-asg'
+      LaunchTemplate:
+        LaunchTemplateId: !Ref LaunchTemplate
+        Version: !GetAtt LaunchTemplate.LatestVersionNumber
+      MinSize: 1
+      MaxSize: 1
+      DesiredCapacity: 1
+      HealthCheckType: EC2
+      HealthCheckGracePeriod: 300
+      AvailabilityZones:
+        - !Select
+          - 0
+          - !GetAZs ''
+      Tags:
+        - Key: Name
+          Value: !Sub '${EnvironmentName}-asg'
+          PropagateAtLaunch: false
+    UpdatePolicy:
+      AutoScalingReplacingUpdate:
+        WillReplace: true
+
+  # Elastic IP for consistent public addressing
+  ElasticIP:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: !Sub '${EnvironmentName}-eip'
+
+Outputs:
+  ECRRepositoryUri:
+    Description: ECR Repository URI
+    Value: !GetAtt ECRRepository.RepositoryUri
+    Export:
+      Name: !Sub '${EnvironmentName}-ecr-uri'
+
+  ECRRepositoryName:
+    Description: ECR Repository Name
+    Value: !Ref ECRRepository
+    Export:
+      Name: !Sub '${EnvironmentName}-ecr-name'
+
+  SecurityGroupId:
+    Description: Security Group ID
+    Value: !Ref YAWSSecurityGroup
+    Export:
+      Name: !Sub '${EnvironmentName}-sg-id'
+
+  AutoScalingGroupName:
+    Description: Auto Scaling Group Name
+    Value: !Ref AutoScalingGroup
+    Export:
+      Name: !Sub '${EnvironmentName}-asg-name'
+
+  ElasticIPAddress:
+    Description: Elastic IP Address
+    Value: !Ref ElasticIP
+    Export:
+      Name: !Sub '${EnvironmentName}-eip'
+
+  InstanceRole:
+    Description: IAM Role for EC2 Instance
+    Value: !Ref EC2InstanceRole
+    Export:
+      Name: !Sub '${EnvironmentName}-instance-role'

--- a/src/main/java/com/brcsrc/yaws/model/Constants.java
+++ b/src/main/java/com/brcsrc/yaws/model/Constants.java
@@ -13,6 +13,9 @@ public class Constants {
     // ip related fields
     public static final String IPV4_CIDR_REGEXP = "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(3[0-2]|[1-2][0-9]|[0-9]))$";
     public static final String IPV4_ADDRESS_REGEXP = "^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])$";
+    public static final String FQDN_REGEXP = "^(?=.{1,253}$)(?:(?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)*(?!-)[A-Za-z0-9-]{1,63}(?<!-)$";
+    // origin validation for CORS (scheme://host:port)
+    public static final String ORIGIN_REGEXP = "^(https?://)((([a-zA-Z0-9-]+\\.)*[a-zA-Z0-9-]+)|((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9]))(:[0-9]{1,5})?$";
     // admin user row id is always 1L because we can only have one
     public static final Long ADMIN_USER_ID = 1L;
     public static final int ADMIN_USER_PASSWORD_MIN_LENGTH = 12;

--- a/src/main/java/com/brcsrc/yaws/utility/IPUtils.java
+++ b/src/main/java/com/brcsrc/yaws/utility/IPUtils.java
@@ -15,6 +15,14 @@ public class IPUtils {
         return address.matches(Constants.IPV4_ADDRESS_REGEXP);
     }
 
+    public static boolean isValidFQDN(String fqdn) {
+        return fqdn.matches(Constants.FQDN_REGEXP);
+    }
+
+    public static boolean isValidOrigin(String origin) {
+        return origin.matches(Constants.ORIGIN_REGEXP);
+    }
+
     public static boolean isValidClientConfigEndpoint(String endpoint) {
         String[] parts = endpoint.split(":");
         if (parts.length != 2) {

--- a/yaws-frontend/package.json
+++ b/yaws-frontend/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
-    "build-dev": "vite build",
+    "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/yaws-frontend/src/App.tsx
+++ b/yaws-frontend/src/App.tsx
@@ -26,10 +26,10 @@ const AuthenticatedRoutes = () => {
         <Route path="/" element={<Dashboard />} />
         <Route path="/networks" element={<Networks />} />
         <Route path="/networks/create" element={<CreateNetwork />} />
+        <Route path="/networks/:networkName" element={<Network />} />
         <Route path="/networks/:networkName/update" element={<UpdateNetwork />} />
         <Route path="/networks/:networkName/clients/create" element={<CreateClient />} />
         <Route path="/networks/:networkName/clients/:clientName" element={<Client />} />
-        <Route path="/networks/:networkName" element={<Network />} />
     </Routes>
 }
 

--- a/yaws-frontend/src/utils/clients.ts
+++ b/yaws-frontend/src/utils/clients.ts
@@ -42,7 +42,8 @@ const errorMiddleware: Middleware = {
 };
 
 const config = new Configuration({
-    credentials: "include", // Include cookies in all requests
+    basePath: window.location.origin,   // use relative urls
+    credentials: "include",             // Include cookies in all requests
     middleware: [errorMiddleware],
 });
 


### PR DESCRIPTION
This PR adds some changes to allow yaws to deploy and run from an ec2 instance. for this we needed:
- add a way to insert CORS configuration into spring security filter and validate origin
- add cloudformation template for a minimal deployment on ec2
- add script to deploy infra and refresh instance after image is pushed to ecr (infrastructure has a ASG with 1/1 instances to provide a separate interface to update the app on change)
- not a part of this PR but had to make [JnbRelay accept different MIME/content types](https://github.com/brcsrc/JnbRelay/commit/ed6ab6d787b31820e94a1cb690aa1d6c250b9f31) to make this work with TLS

why this is valuable: we may not need to start the app with `--privileged` option in docker. to make this app more useable we should explore paring this down to see if we can still function with less overall privileges, also Fargate probably wont work with privileged mode etc. this will be worked in a separate commit

