### PR TITLE
fix network masquerade issues in docker compose environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,28 @@
 
 YetAnotherWireguardServer is a containerized Wireguard server designed to run anywhere you can run Docker.
 
-##### Try it yourself
-1. Clone the Repository
+## Table of Contents
+- [Deploying YetAnotherWireguardServer](#deploying-yetanotherwireguardserver)
+  - [Quick Start (docker run)](#quick-start-docker-run)
+  - [Docker Compose](#docker-compose)
+- [Environment Variables](#environment-variables)
+- [Links](#links)
+
+---
+
+## Deploying YetAnotherWireguardServer
+
+### Quick Start (docker run)
+
+1. Clone the repository
 ```shell
 git clone https://github.com/brcsrc/YetAnotherWireguardServer
 ```
-2. Build the Image
-> Requires Docker
+2. Build the image
 ```shell
 cd YetAnotherWireguardServer && docker build -f docker/prod/Dockerfile -t yaws .
 ```
-3. Run the Application with necessary network settings
+3. Run with the required network capabilities
 ```shell
 docker run \
  --privileged \
@@ -26,6 +37,41 @@ docker run \
  yaws:latest
 ```
 
+### Docker Compose
+
+When running YAWS in a compose stack, you must explicitly enable IP masquerading on any custom network. Without it, WireGuard clients will connect but have no internet access — `docker run` works out of the box because Docker's default bridge has masquerading enabled, but custom compose networks do not.
+
+WireGuard traffic requires two NAT hops to reach the internet: client IPs masqueraded to the container IP (handled by YAWS), and the container IP masqueraded to the host's public IP (handled by Docker — but only if the network has masquerading enabled).
+
+```yaml
+services:
+  yaws:
+    image: yaws:latest
+    container_name: yaws
+    privileged: true
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - "0.0.0.0:51820:51820/udp"
+      - "0.0.0.0:8080:8080/tcp"
+    restart: unless-stopped
+    networks:
+      yaws-net:
+        ipv4_address: 172.25.0.20
+
+networks:
+  yaws-net:
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.enable_ip_masquerade: "true"
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.25.0.0/16
+```
+
+---
+
 ## Environment Variables
 
 | Variable | Description | Example |
@@ -33,9 +79,10 @@ docker run \
 | `DEV` | Enables development mode (allows Swagger UI, permits localhost CORS) | `-e DEV="true"` |
 | `CORS_ALLOWED_ORIGINS` | Comma-separated list of allowed CORS origins, usually needed when deployed behind a proxy | `-e CORS_ALLOWED_ORIGINS="https://example.com,https://app.example.com"` |
 
-##### *Links*
+---
+
+## Links
 
 - [Development](doc/DEVELOPMENT.md)
 - [Spring Docs](doc/HELP.md)
 - [Entity Relationship Diagram](doc/yaws-erd.drawio)
-- [Insomnia Request Model](doc/Insomnia_2025-03-20.json)

--- a/docker/dev/entrypoint.sh
+++ b/docker/dev/entrypoint.sh
@@ -16,7 +16,7 @@ SAVE_ON_STOP="yes"
 IPFORWARD="yes"
 ' > /etc/conf.d/iptables
 /etc/init.d/iptables save
-iptables-restore < /etc/iptables/rules.v4
+iptables-restore --noflush < /etc/iptables/rules.v4
 
 # enable ip forward in sysctl
 echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf

--- a/docker/prod/entrypoint.sh
+++ b/docker/prod/entrypoint.sh
@@ -16,7 +16,7 @@ SAVE_ON_STOP="yes"
 IPFORWARD="yes"
 ' > /etc/conf.d/iptables
 /etc/init.d/iptables save
-iptables-restore < /etc/iptables/rules.v4
+iptables-restore --noflush < /etc/iptables/rules.v4
 
 # enable ip forward in sysctl
 echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf

--- a/docker/test/entrypoint.sh
+++ b/docker/test/entrypoint.sh
@@ -16,7 +16,7 @@ SAVE_ON_STOP="yes"
 IPFORWARD="yes"
 ' > /etc/conf.d/iptables
 /etc/init.d/iptables save
-iptables-restore < /etc/iptables/rules.v4
+iptables-restore --noflush < /etc/iptables/rules.v4
 
 # enable ip forward in sysctl
 echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf

--- a/shell/configure-iptables
+++ b/shell/configure-iptables
@@ -8,7 +8,6 @@ function add_network() {
   iptables -I INPUT -s "$network_cidr" -j ACCEPT
   iptables -t nat -A POSTROUTING -s "$network_cidr" -o eth0 -j MASQUERADE
   iptables-save > /etc/iptables/rules.v4
-  rc-service iptables restart
 }
 
 function remove_network() {
@@ -18,7 +17,6 @@ function remove_network() {
   iptables -D INPUT -s "$network_cidr" -j ACCEPT
   iptables -t nat -D POSTROUTING -s "$network_cidr" -o eth0 -j MASQUERADE
   iptables-save > /etc/iptables/rules.v4
-  rc-service iptables restart
 }
 
 function main() {


### PR DESCRIPTION
I was running into issues running YAWS on my home server, which uses a custom network in docker compose. Clients were getting handshakes but traffic was not being forwarded because:
1. no masquerade rules were created on the custom network
2. scripts that configure iptables were dumping all previous rules on update
