### PR TITLE
replace emoji in navbar with proper element

### DIFF
--- a/yaws-frontend/src/components/layout/ThemeIcon.tsx
+++ b/yaws-frontend/src/components/layout/ThemeIcon.tsx
@@ -1,0 +1,18 @@
+const ThemeIcon = ({ isDark }: { isDark: boolean }) => (
+  <svg
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    style={{
+      transform: isDark ? "none" : "rotate(180deg)",
+      transition: "transform 0.3s ease",
+    }}
+  >
+    <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1" fill="none" />
+    <path d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1V15Z" fill="currentColor" />
+  </svg>
+);
+
+export default ThemeIcon;

--- a/yaws-frontend/src/components/layout/TopNavigation.tsx
+++ b/yaws-frontend/src/components/layout/TopNavigation.tsx
@@ -1,8 +1,7 @@
 import TopNavigation from "@cloudscape-design/components/top-navigation";
-import Toggle from "@cloudscape-design/components/toggle";
 import { useThemeContext } from "../../context/ThemeContextProvider";
 import { useAuthContext } from "../../context/AuthContextProvider";
-import { SpaceBetween } from "@cloudscape-design/components";
+import ThemeIcon from "./ThemeIcon";
 
 const TopNavigationBar = (): JSX.Element => {
   const { theme, toggleTheme } = useThemeContext();
@@ -78,14 +77,21 @@ const TopNavigationBar = (): JSX.Element => {
           borderBottom: "solid #424650 1px",
         }}
       >
-        <SpaceBetween size={"xs"} direction={"horizontal"} alignItems={"center"}>
-          🌙
-          <Toggle
-            checked={theme === "dark"}
-            onChange={() => toggleTheme()}
-            ariaLabel="Toggle dark mode"
-          />
-        </SpaceBetween>
+        <button
+          onClick={toggleTheme}
+          aria-label="Toggle dark mode"
+          style={{
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            color: "#ffffff",
+            padding: 0,
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <ThemeIcon isDark={theme === "dark"} />
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
there was previously a moon emoji in the navbar that looked kind of wonky, replaced with an inline svg borrowed from cloudscape design instead 