### PR TITLE
fix bug where too long of network names were allowed

### DIFF
--- a/src/main/java/com/brcsrc/yaws/model/Constants.java
+++ b/src/main/java/com/brcsrc/yaws/model/Constants.java
@@ -9,7 +9,7 @@ public class Constants {
     public static final String BASE_WIREGUARD_DIR = "/etc/wireguard";
     // input validation regular expressions
     // network and client names
-    public static final String CHAR_64_ALPHANUMERIC_DASHES_UNDERSC_REGEXP = "^[a-zA-Z0-9_-]{4,64}$";
+    public static final String CHAR_15_ALPHANUMERIC_DASHES_UNDERSC_REGEXP = "^[a-zA-Z0-9_-]{4,15}$";
     // ip related fields
     public static final String IPV4_CIDR_REGEXP = "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(3[0-2]|[1-2][0-9]|[0-9]))$";
     public static final String IPV4_ADDRESS_REGEXP = "^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])$";

--- a/src/main/java/com/brcsrc/yaws/model/Network.java
+++ b/src/main/java/com/brcsrc/yaws/model/Network.java
@@ -18,7 +18,7 @@ public class Network {
 
     @Id
     @NotNull
-    @Pattern(regexp = Constants.CHAR_64_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)
+    @Pattern(regexp = Constants.CHAR_15_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)
     @Schema(description = "unique, alphanumeric, 1-64 character name for the network")
     private String networkName;
 

--- a/src/main/java/com/brcsrc/yaws/service/NetworkClientService.java
+++ b/src/main/java/com/brcsrc/yaws/service/NetworkClientService.java
@@ -26,10 +26,7 @@ import com.brcsrc.yaws.utility.FilepathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.web.server.ResponseStatusException;
@@ -112,12 +109,12 @@ public class NetworkClientService {
         }
 
         // check network name and client name are valid
-        if (!request.getNetworkName().matches(Constants.CHAR_64_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
+        if (!request.getNetworkName().matches(Constants.CHAR_15_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
             String errMsg = "networkName is not valid";
             logger.error(errMsg);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errMsg);
         }
-        if (!request.getClientName().matches(Constants.CHAR_64_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
+        if (!request.getClientName().matches(Constants.CHAR_15_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
             String errMsg = "clientName is not valid";
             logger.error(errMsg);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errMsg);
@@ -343,7 +340,7 @@ public class NetworkClientService {
     @Transactional
     public NetworkClient deleteNetworkClient(String networkName, String clientName) {
         // input validation
-        if (!networkName.matches(Constants.CHAR_64_ALPHANUMERIC_DASHES_UNDERSC_REGEXP) || !clientName.matches(Constants.CHAR_64_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
+        if (!networkName.matches(Constants.CHAR_15_ALPHANUMERIC_DASHES_UNDERSC_REGEXP) || !clientName.matches(Constants.CHAR_15_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
             String errMsg = "network name or client name is invalid";
             logger.error(errMsg);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errMsg);
@@ -427,12 +424,12 @@ public class NetworkClientService {
 
     private String getNetworkClientConfigFileContent(String networkName, String clientName) {
         // validate inputs before putting them in jpa queries
-        if (!networkName.matches(Constants.CHAR_64_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
+        if (!networkName.matches(Constants.CHAR_15_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
             String errMsg = "networkName is not valid";
             logger.error(errMsg);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errMsg);
         }
-        if (!clientName.matches(Constants.CHAR_64_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
+        if (!clientName.matches(Constants.CHAR_15_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
             String errMsg = "clientName is not valid";
             logger.error(errMsg);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errMsg);
@@ -508,7 +505,7 @@ public class NetworkClientService {
 
     public String getNextAvailableClientAddress(String networkName) {
         // check networkName is valid input
-        if (!networkName.matches(Constants.CHAR_64_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
+        if (!networkName.matches(Constants.CHAR_15_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
             String errMsg = "networkName is not valid";
             logger.error(errMsg);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errMsg);

--- a/src/main/java/com/brcsrc/yaws/service/NetworkService.java
+++ b/src/main/java/com/brcsrc/yaws/service/NetworkService.java
@@ -81,8 +81,8 @@ public class NetworkService {
     }
 
     public Network createNetwork(Network network) {
-        if (!network.getNetworkName().matches(Constants.CHAR_64_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
-            String errMsg = "networkName must be alphanumeric without spaces and no more than 64 characters";
+        if (!network.getNetworkName().matches(Constants.CHAR_15_ALPHANUMERIC_DASHES_UNDERSC_REGEXP)) {
+            String errMsg = "networkName must be alphanumeric without spaces and no more than 15 characters";
             logger.error(errMsg);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errMsg);
         }
@@ -167,7 +167,7 @@ public class NetworkService {
                     "command: '%s' exited %s with reason: %s",
                     createKeyPairCommand,
                     createKeyPairExecResult.getExitCode(),
-                    createKeyPairExecResult.getStdout()));
+                    createKeyPairExecResult.getStderr()));
             // mark the network for removal
             network.setNetworkStatus(NetworkStatus.INACTIVE);
             this.networkRepository.save(network);
@@ -206,7 +206,7 @@ public class NetworkService {
                     "command: '%s' exited %s with reason: %s",
                     createNetworkConfigCommand,
                     createNetConfigExecResult.getExitCode(),
-                    createNetConfigExecResult.getStdout()));
+                    createNetConfigExecResult.getStderr()));
             network.setNetworkStatus(NetworkStatus.INACTIVE);
             this.networkRepository.save(network);
             CompletableFuture<Network> deletedNetworkFuture = asyncRemoveNetworkFromSystem(network);
@@ -242,7 +242,7 @@ public class NetworkService {
                     "command: '%s' exited %s with reason: %s",
                     wgUpCommand,
                     wgUpExecResult.getExitCode(),
-                    wgUpExecResult.getStdout()));
+                    wgUpExecResult.getStderr()));
             network.setNetworkStatus(NetworkStatus.INACTIVE);
             this.networkRepository.save(network);
             CompletableFuture<Network> deletedNetworkFuture = asyncRemoveNetworkFromSystem(network);
@@ -275,7 +275,7 @@ public class NetworkService {
                             "command: '%s' exited %s with reason: %s",
                             wgDownCommand,
                             wgDownExecResult.getExitCode(),
-                            wgDownExecResult.getStdout()));
+                            wgDownExecResult.getStderr()));
                 }
             } else {
                 logger.info(String.format("wireguard interface '%s' does not exist", network.getNetworkName()));
@@ -295,7 +295,7 @@ public class NetworkService {
                         "command: '%s' exited %s with reason: %s",
                         configureIptablesCommand,
                         configureIptablesExecResult.getExitCode(),
-                        configureIptablesExecResult.getStdout()));
+                        configureIptablesExecResult.getStderr()));
             }
 
             // remove the files. not needed for wireguard but keeps disk space down
@@ -492,7 +492,7 @@ public class NetworkService {
         ExecutionResult wgDownResult = Executor.runCommand(wgDownCommand);
         if (wgDownResult.getExitCode() != 0) {
             String errMsg = String.format("Failed to bring down WireGuard interface for network '%s': %s",
-                    network.getNetworkName(), wgDownResult.getStdout());
+                    network.getNetworkName(), wgDownResult.getStderr());
             logger.error(errMsg);
             throw new InternalServerException(errMsg);
         }
@@ -517,7 +517,7 @@ public class NetworkService {
         ExecutionResult wgUpResult = Executor.runCommand(wgUpCommand);
         if (wgUpResult.getExitCode() != 0) {
             String errMsg = String.format("Failed to bring up WireGuard interface for network '%s': %s",
-                    network.getNetworkName(), wgUpResult.getStdout());
+                    network.getNetworkName(), wgUpResult.getStderr());
             logger.error(errMsg);
             throw new InternalServerException(errMsg);
         }

--- a/src/test/java/com/brcsrc/yaws/api/NetworkControllerTests.java
+++ b/src/test/java/com/brcsrc/yaws/api/NetworkControllerTests.java
@@ -180,9 +180,9 @@ public class NetworkControllerTests {
     @Test
     public void testCreateNetworkRejectsInvalidNetworkNames() {
         var badNames = List.of(
-                "name with spaces",
-                "name-with-%@$-chars",
-                "name-with-too-many-characters-12345678910111213141516171819202101"
+                "name w spaces",
+                "name-with-%@$",
+                "sixteencharsname"
         );
 
         for (String s : badNames) {
@@ -205,7 +205,7 @@ public class NetworkControllerTests {
             String responseBody = response.getBody();
             assert responseBody != null;
 
-            assertTrue(responseBody.contains("networkName must be alphanumeric without spaces and no more than 64 characters"));
+            assertTrue(responseBody.contains("networkName must be alphanumeric without spaces and no more than 15 characters"));
             Optional<Network> networkFromDb = networkRepository.findByNetworkName(s);
             assert networkFromDb.isEmpty();
         }
@@ -292,7 +292,7 @@ public class NetworkControllerTests {
         assert networkFromDb.isPresent();
 
         Network networkWithAddressAlreadyInUse = new Network();
-        networkWithAddressAlreadyInUse.setNetworkName("NotTestNetworkName");
+        networkWithAddressAlreadyInUse.setNetworkName("NotTestNetName");
         networkWithAddressAlreadyInUse.setNetworkCidr(testNetworkCidr);
         networkWithAddressAlreadyInUse.setNetworkListenPort(51821);
         networkWithAddressAlreadyInUse.setNetworkTag("not test network tag");
@@ -340,7 +340,7 @@ public class NetworkControllerTests {
         assert networkFromDb.isPresent();
 
         Network networkWithListenPortAlreadyInUse = new Network();
-        networkWithListenPortAlreadyInUse.setNetworkName("NotTestNetworkName");
+        networkWithListenPortAlreadyInUse.setNetworkName("NotTestNetName");
         networkWithListenPortAlreadyInUse.setNetworkCidr("192.168.0.1/24");
         networkWithListenPortAlreadyInUse.setNetworkListenPort(testNetworkListenPort); // Same listen port
         networkWithListenPortAlreadyInUse.setNetworkTag("not_test_network_tag");

--- a/yaws-frontend/src/pages/network/CreateNetwork.tsx
+++ b/yaws-frontend/src/pages/network/CreateNetwork.tsx
@@ -27,6 +27,32 @@ const CreateNetwork = () => {
   const [showErrorText, setShowErrorText] = useState(false);
   const [loading, setLoading] = useState(false);
 
+  // Regex patterns for validity borrowed from backed Constants.java
+
+  const isNetworkNameInvalid = networkName.length > 0 && !/^[a-zA-Z0-9_-]{4,15}$/.test(networkName);
+
+  const isNetworkIpInvalid =
+    networkIp.length > 0 &&
+    !/^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])$/.test(networkIp);
+
+  const networkInterfaceOctet = parseInt(networkIp.split(".")[3]);
+  const isNetworkIpHostInvalid =
+    networkIp.length > 0 &&
+    !isNetworkIpInvalid &&
+    (networkInterfaceOctet === 0 || networkInterfaceOctet > 254);
+
+  const subnetMaskValue = parseInt(networkSubnetMask.replace("/", ""));
+  const isSubnetMaskInvalid =
+    networkSubnetMask.length > 0 &&
+    (isNaN(subnetMaskValue) || subnetMaskValue < 24 || subnetMaskValue > 32);
+
+  const listenPortValue = parseInt(networkListenPort);
+  const isListenPortInvalid =
+    networkListenPort.length > 0 && (isNaN(listenPortValue) || listenPortValue < 1025 || listenPortValue > 65535);
+
+  const isNetworkTagInvalid =
+    networkTag.length > 0 && !/^[a-zA-Z0-9_-]{1,64}$/.test(networkTag);
+
   const handleSubmit = async () => {
     setLoading(true);
     try {
@@ -68,7 +94,12 @@ const CreateNetwork = () => {
       networkIp.trim() !== "" &&
       networkSubnetMask.trim() !== "" &&
       networkListenPort.trim() !== "" &&
-      !isNaN(parseInt(networkListenPort))
+      !isNetworkNameInvalid &&
+      !isNetworkIpInvalid &&
+      !isNetworkIpHostInvalid &&
+      !isSubnetMaskInvalid &&
+      !isListenPortInvalid &&
+      !isNetworkTagInvalid
     );
   };
 
@@ -112,18 +143,29 @@ const CreateNetwork = () => {
               <SpaceBetween size="l">
                 <FormField
                   label="Network name"
-                  description="Unique, alphanumeric, 1-64 character name for the network"
+                  description="Unique, alphanumeric, 4-15 character name for the network"
+                  errorText={isNetworkNameInvalid ? "Network name must be 4-15 alphanumeric characters, dashes, or underscores" : undefined}
                 >
                   <Input
                     value={networkName}
                     onChange={({ detail }) => setNetworkName(detail.value)}
                     placeholder="e.g., Network1"
+                    invalid={isNetworkNameInvalid}
                   />
                 </FormField>
 
                 <FormField
                   label="Network IP address / Subnet mask"
                   description="IP address and subnet mask for the network (typically /24)"
+                  errorText={
+                    isNetworkIpInvalid
+                      ? "Must be a valid IPv4 address"
+                      : isNetworkIpHostInvalid
+                        ? "Host octet must be between .1 and .254"
+                        : isSubnetMaskInvalid
+                          ? "Subnet mask must be between /24 and /32"
+                          : undefined
+                  }
                 >
                   <div style={{ display: "flex", gap: "8px" }}>
                     <div style={{ flex: "3" }}>
@@ -131,6 +173,7 @@ const CreateNetwork = () => {
                         value={networkIp}
                         onChange={({ detail }) => setNetworkIp(detail.value)}
                         placeholder="e.g., 10.100.0.1"
+                        invalid={isNetworkIpInvalid || isNetworkIpHostInvalid}
                       />
                     </div>
                     <div style={{ flex: "1" }}>
@@ -138,6 +181,7 @@ const CreateNetwork = () => {
                         value={networkSubnetMask}
                         onChange={({ detail }) => setNetworkSubnetMask(detail.value)}
                         placeholder="/24"
+                        invalid={isSubnetMaskInvalid}
                       />
                     </div>
                   </div>
@@ -146,20 +190,27 @@ const CreateNetwork = () => {
                 <FormField
                   label="Network listen port"
                   description="Server listen port for the network (1025-65535)"
+                  errorText={isListenPortInvalid ? "Listen port must be between 1025 and 65535" : undefined}
                 >
                   <Input
                     value={networkListenPort}
                     onChange={({ detail }) => setNetworkListenPort(detail.value)}
                     placeholder="e.g., 51820"
                     type="number"
+                    invalid={isListenPortInvalid}
                   />
                 </FormField>
 
-                <FormField label="Network tag" description="Optional tag for the network">
+                <FormField
+                  label="Network tag"
+                  description="Optional tag for the network"
+                  errorText={isNetworkTagInvalid ? "Tag must be alphanumeric with dashes or underscores, max 64 characters" : undefined}
+                >
                   <Input
                     value={networkTag}
                     onChange={({ detail }) => setNetworkTag(detail.value)}
                     placeholder="e.g., net1"
+                    invalid={isNetworkTagInvalid}
                   />
                 </FormField>
               </SpaceBetween>


### PR DESCRIPTION
### Summary
   When deployed in the homelab I was trying to create a network with the name `temp-remote-network` (19 chars) and was getting a 500 from the network controller. Apparently I missed that the linux kernel only allows for interface names of 15 chars max https://github.com/torvalds/linux/blob/master/include/uapi/linux/if.h#L33, so the previous 64 char allowance was incorrect.

this change does the following
- upates CreateNetwork API to expect 4-16 char alphanumeric with dashes and underscores for network names
- updates the catch blocks in CreateNetwork to look for the `stderr` and not the `stdout` that is empty on error
- update tests accordingly

### Testing
- test suite passing
- local behavior tests on frontend looks good

