### PR TITLE
allow admin user create from environment variables - issue 54

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ networks:
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `DEV` | Enables development mode (allows Swagger UI, permits localhost CORS) | `-e DEV="true"` |
-| `CORS_ALLOWED_ORIGINS` | Comma-separated list of allowed CORS origins, usually needed when deployed behind a proxy | `-e CORS_ALLOWED_ORIGINS="https://example.com,https://app.example.com"` |
+| `YAWS_ADMIN_USERNAME` | If set alongside `YAWS_ADMIN_PASSWORD`, registers the admin user on startup if one does not already exist | `-e YAWS_ADMIN_USERNAME="admin"` |
+| `YAWS_ADMIN_PASSWORD` | Password for the admin user registered via `YAWS_ADMIN_USERNAME`. Must meet complexity requirements (12+ chars, 2 uppercase, 2 lowercase, 1 number, 1 special character) | `-e YAWS_ADMIN_PASSWORD="Str0ng!Pass#1"` |
+| `YAWS_DEV` | Enables development mode (allows Swagger UI, permits localhost CORS) | `-e YAWS_DEV="true"` |
+| `YAWS_CORS_ALLOWED_ORIGINS` | Comma-separated list of allowed CORS origins, usually needed when deployed behind a proxy | `-e YAWS_CORS_ALLOWED_ORIGINS="https://example.com,https://app.example.com"` |
 
 ---
 

--- a/doc/DEVELOPMENT.md
+++ b/doc/DEVELOPMENT.md
@@ -35,7 +35,7 @@ docker build -f docker/dev/Dockerfile -t yaws . && \
 docker run \
  --privileged \
  --cap-add=NET_ADMIN \
- -e DEV="true" \
+ -e YAWS_DEV="true" \
  -p 0.0.0.0:51820:51820/udp \
  -p 0.0.0.0:8080:8080/tcp \
  --name yaws \

--- a/scripts/ec2-based-infrastructure.yml
+++ b/scripts/ec2-based-infrastructure.yml
@@ -190,7 +190,7 @@ Resources:
             docker run \
               --privileged \
               --cap-add=NET_ADMIN \
-              -e CORS_ALLOWED_ORIGINS="https://$PUBLIC_DNS" \
+              -e YAWS_CORS_ALLOWED_ORIGINS="https://$PUBLIC_DNS" \
               -p 0.0.0.0:51820:51820/udp \
               -p 127.0.0.1:8080:8080/tcp \
               --name yaws \

--- a/src/main/java/com/brcsrc/yaws/security/SecurityConfiguration.java
+++ b/src/main/java/com/brcsrc/yaws/security/SecurityConfiguration.java
@@ -42,7 +42,7 @@ public class SecurityConfiguration {
         List<String> allowedOrigins = new ArrayList<>();
 
         // load allowed origins from environment
-        String allowedOriginsFromEnv = System.getenv("CORS_ALLOWED_ORIGINS");
+        String allowedOriginsFromEnv = System.getenv("YAWS_CORS_ALLOWED_ORIGINS");
         if (allowedOriginsFromEnv != null && !allowedOriginsFromEnv.isBlank()) {
             String[] origins = allowedOriginsFromEnv.split(",");
             for (String origin : origins) {
@@ -56,7 +56,7 @@ public class SecurityConfiguration {
         }
 
         // allow access from vite if started in dev
-        boolean isDev = Boolean.parseBoolean(System.getenv("DEV"));
+        boolean isDev = Boolean.parseBoolean(System.getenv("YAWS_DEV"));
         if (isDev) {
             allowedOrigins.add("http://localhost:5173");
         }
@@ -109,7 +109,7 @@ public class SecurityConfiguration {
                     ).permitAll();
 
                     // Allow Swagger and OpenAPI docs in development mode
-                    boolean isDev = Boolean.parseBoolean(System.getenv("DEV"));
+                    boolean isDev = Boolean.parseBoolean(System.getenv("YAWS_DEV"));
                     if (isDev) {
                         registry.requestMatchers(
                                 "/swagger-ui/**",           // Swagger UI static resources

--- a/src/main/java/com/brcsrc/yaws/startup/StartupListener.java
+++ b/src/main/java/com/brcsrc/yaws/startup/StartupListener.java
@@ -20,6 +20,7 @@ public class StartupListener {
     @EventListener(ApplicationReadyEvent.class)
     public void onStartup() {
         logger.info("Application is ready, executing start up tasks");
+        this.startupTasks.registerAdminUserFromEnv();
         this.startupTasks.restartActiveNetworks();
     }
 }

--- a/src/main/java/com/brcsrc/yaws/startup/StartupTasks.java
+++ b/src/main/java/com/brcsrc/yaws/startup/StartupTasks.java
@@ -3,7 +3,11 @@ package com.brcsrc.yaws.startup;
 import com.brcsrc.yaws.exceptions.InternalServerException;
 import com.brcsrc.yaws.model.Network;
 import com.brcsrc.yaws.model.NetworkStatus;
+import com.brcsrc.yaws.model.User;
+import com.brcsrc.yaws.model.Constants;
 import com.brcsrc.yaws.persistence.NetworkRepository;
+import com.brcsrc.yaws.persistence.UserRepository;
+import com.brcsrc.yaws.service.UserService;
 import com.brcsrc.yaws.shell.ExecutionResult;
 import com.brcsrc.yaws.shell.Executor;
 import org.slf4j.Logger;
@@ -17,11 +21,37 @@ import java.util.List;
 @Component
 public class StartupTasks {
     private final NetworkRepository networkRepository;
+    private final UserRepository userRepository;
+    private final UserService userService;
     private static final Logger logger = LoggerFactory.getLogger(StartupTasks.class);
 
     @Autowired
-    public StartupTasks(NetworkRepository networkRepository) {
+    public StartupTasks(NetworkRepository networkRepository, UserRepository userRepository, UserService userService) {
         this.networkRepository = networkRepository;
+        this.userRepository = userRepository;
+        this.userService = userService;
+    }
+
+    public void registerAdminUserFromEnv() {
+        String username = System.getenv("YAWS_ADMIN_USERNAME");
+        String password = System.getenv("YAWS_ADMIN_PASSWORD");
+
+        if (username == null || password == null) {
+            logger.info("YAWS_ADMIN_USERNAME or YAWS_ADMIN_PASSWORD not set, skipping env-based admin registration");
+            return;
+        }
+
+        if (userRepository.findById(Constants.ADMIN_USER_ID).isPresent()) {
+            logger.info("admin user already exists, skipping env-based admin registration");
+            return;
+        }
+
+        logger.info("registering admin user from environment variables");
+        User user = new User();
+        user.setUserName(username);
+        user.setPassword(password);
+        userService.createAdminUser(user);
+        logger.info("admin user registered successfully from environment variables");
     }
 
     @Async

--- a/src/main/java/com/brcsrc/yaws/utility/HeaderUtils.java
+++ b/src/main/java/com/brcsrc/yaws/utility/HeaderUtils.java
@@ -20,7 +20,7 @@ public class HeaderUtils {
                 "Path=/; " +                                                       // use on all paths on the site
                 "Max-Age=" + Constants.AUTH_TOKEN_VALIDITY_PERIOD_SECONDS + "; ";  // time in seconds before the browser deletes the cookie
 
-        boolean isDev = Boolean.parseBoolean(System.getenv("DEV"));
+        boolean isDev = Boolean.parseBoolean(System.getenv("YAWS_DEV"));
         if (isDev) {
             cookieValue += "Domain=localhost; ";                                    // share cookie across all localhost ports (5173 and 8080)
             cookieValue += "SameSite=Lax;";                                         // if dev allow cross origin use of the cookie for vite dev server
@@ -41,7 +41,7 @@ public class HeaderUtils {
                 "Path=/; " +
                 "Max-Age=0; ";  // This expires the cookie immediately
 
-        boolean isDev = Boolean.parseBoolean(System.getenv("DEV"));
+        boolean isDev = Boolean.parseBoolean(System.getenv("YAWS_DEV"));
         if (isDev) {
             cookieValue += "Domain=localhost; ";
             cookieValue += "SameSite=Lax;";


### PR DESCRIPTION
### Summary 

this changes allows the user to create a admin user from environment variables, more details in https://github.com/brcsrc/YetAnotherWireguardServer/issues/54

### Testing 

- ran all tests, no regressions
- launched locally and got logs. was able to log in with the credentials set in environment variable
```
2026-06-14 20:42:50 2026-06-15T02:42:50.885Z  INFO 145 --- [yaws] [           main] com.brcsrc.yaws.startup.StartupTasks     : registering admin user from environment variables
2026-06-14 20:42:51 2026-06-15T02:42:51.055Z  INFO 145 --- [yaws] [           main] com.brcsrc.yaws.service.UserService      : successfully created admin user
```